### PR TITLE
Update postgres-workload.yaml

### DIFF
--- a/postgres/postgres-workload.yaml
+++ b/postgres/postgres-workload.yaml
@@ -21,9 +21,9 @@ spec:
                 name: postgres-config
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
-              name: postgredb
+              name: postgresdb
       volumes:
-        - name: postgredb
+        - name: postgresdb
           persistentVolumeClaim:
             claimName: postgres-pv-claim
 ---


### PR DESCRIPTION
there where 2 typos (**postgredb** instead of **postgresdb**) in line 26 & line 26.

After this change the `kubectl apply -f ...yaml` at least goes through without errors. I have not been able to test anything beyond that point yet though. But still ... better then before